### PR TITLE
systemprobe: Implement ZRender VT call in LoadGlide

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,15 @@ Below each of the files in the decomp is discussed along with a percentage indic
 **globals.dll** [20kb]
 **100%** Completed - **1** out of **1** functions named.
 
+**systemprobedll.dll** [68kb]
+**100%** Completed - **53** out of **53** functions named.
+
 <br>
 
 ### Being Decompiled 📝
 
 **system.dll** [272kb]
 **50%** Completed - **544** out of **552** functions named.
-
-**systemprobedll.dll** [68kb]
-**99%** Completed - **53** out of **53** functions named.
 
 **renderopengl.dll** [248kb]
 **0%** Completed - **240** out of **464** functions named.

--- a/src_main/systemprobe/csystemprobe.cpp
+++ b/src_main/systemprobe/csystemprobe.cpp
@@ -1140,7 +1140,21 @@ i32 CSystemProbe::InitOpenGL()
 
 i32 CSystemProbe::LoadGlide()
 {
-    // TODO: Add ZRender VT call, see original function.
+    if (g_pSysInterface && g_pSysInterface->m_zRender)
+    {
+        class DummyZRender {};
+        typedef const char* (DummyZRender::*GetRendererName_t)();
+        DummyZRender* zRender = reinterpret_cast<DummyZRender*>(g_pSysInterface->m_zRender);
+        void** vtable = *reinterpret_cast<void***>(zRender);
+        GetRendererName_t GetRendererName;
+        *reinterpret_cast<void**>(&GetRendererName) = vtable[82];
+        const char* rendererName = (zRender->*GetRendererName)();
+        if (rendererName && _stricmp(rendererName, "GLIDE3") == 0)
+        {
+            m_flags |= 4;
+            return 0;
+        }
+    }
 
     i32 l_numBoards = 0;
     bool l_glideLoaded = 0;


### PR DESCRIPTION
Reversed the missing Glide detection check from the original SystemProbeDLL.dll:
- Queries the active renderer's name using the virtual method at offset 0x148 (index 82) of g_pSysInterface->m_zRender (offset 0x37e5).
- If the name matches "GLIDE3" (case-insensitive), it sets the glide flag (m_flags |= 4) and returns early.
- Implemented this using a DummyZRender member function pointer cast to bypass MSVC 6's restrictions on __thiscall function pointers.

Also updated README.md to mark systemprobedll.dll as 100% completed and moved it to the Completed section.
